### PR TITLE
teams に league カラムを追加

### DIFF
--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -3,7 +3,7 @@ module Api
     before_action :set_team, only: %i[show update destroy]
 
     def index
-      teams = Team.order(created_at: :desc)
+      teams = Team.order(created_at: :asc)
       render json: { data: teams }
     end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,2 +1,3 @@
 class Team < ApplicationRecord
+  enum league: { central: 0, pacific: 1 }
 end

--- a/db/fixtures/1000_teams.rb
+++ b/db/fixtures/1000_teams.rb
@@ -1,16 +1,16 @@
 team_list = [
-  { name: '読売ジャイアンツ', founded_year: 1934 },
-  { name: '横浜DeNAベイスターズ', founded_year: 1949 },
-  { name: '阪神タイガース', founded_year: 1935 },
-  { name: '広島東洋カープ', founded_year: 1949 },
-  { name: '中日ドラゴンズ', founded_year: 1936 },
-  { name: '東京ヤクルトスワローズ', founded_year: 1950 },
-  { name: '埼玉西武ライオンズ', founded_year: 1949 },
-  { name: '福岡ソフトバンクホークス', founded_year: 1938 },
-  { name: '東北楽天ゴールデンイーグルス', founded_year: 2004 },
-  { name: '千葉ロッテマリーンズ', founded_year: 1949 },
-  { name: '北海道日本ハムファイターズ', founded_year: 1945 },
-  { name: 'オリックス・バファローズ', founded_year: 1936 },
+  { name: '読売ジャイアンツ', founded_year: 1934, league: 0 },
+  { name: '横浜DeNAベイスターズ', founded_year: 1949, league: 0 },
+  { name: '阪神タイガース', founded_year: 1935, league: 0 },
+  { name: '広島東洋カープ', founded_year: 1949, league: 0 },
+  { name: '中日ドラゴンズ', founded_year: 1936, league: 0 },
+  { name: '東京ヤクルトスワローズ', founded_year: 1950, league: 0 },
+  { name: '埼玉西武ライオンズ', founded_year: 1949, league: 1 },
+  { name: '福岡ソフトバンクホークス', founded_year: 1938, league: 1 },
+  { name: '東北楽天ゴールデンイーグルス', founded_year: 2004, league: 1 },
+  { name: '千葉ロッテマリーンズ', founded_year: 1949, league: 1 },
+  { name: '北海道日本ハムファイターズ', founded_year: 1945, league: 1 },
+  { name: 'オリックス・バファローズ', founded_year: 1936, league: 1 },
 ]
 
 team_list.map do |team|
@@ -19,6 +19,7 @@ team_list.map do |team|
     {
       name: team[:name],
       founded_year: team[:founded_year],
+      league: team[:league],
     }
   )
 end

--- a/db/migrate/20210518114733_add_league_to_teams.rb
+++ b/db/migrate/20210518114733_add_league_to_teams.rb
@@ -1,0 +1,5 @@
+class AddLeagueToTeams < ActiveRecord::Migration[6.0]
+  def change
+    add_column :teams, :league, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_114818) do
+ActiveRecord::Schema.define(version: 2021_05_18_114733) do
 
   create_table "teams", force: :cascade do |t|
     t.string "name", null: false
     t.integer "founded_year", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "league", default: 0, null: false
   end
 
 end


### PR DESCRIPTION
- teams に league カラムを追加
- クライアントサイドに返す teams の順番を `created_at` の昇順に変更