### PR TITLE
GET /api/teams API にチーム成績データを追加

### DIFF
--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -3,7 +3,10 @@ module Api
     before_action :set_team, only: %i[show update destroy]
 
     def index
-      teams = Team.order(created_at: :asc).includes(:results)
+      teams = Team.order(created_at: :asc).includes(:results).as_json(
+        only: %i[id name founded_year league],
+        include: { results: { only: %i[id team_id year rank wins_count loses_count] } },
+      )
       render json: { data: teams }
     end
 

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -3,7 +3,7 @@ module Api
     before_action :set_team, only: %i[show update destroy]
 
     def index
-      teams = Team.order(created_at: :asc)
+      teams = Team.order(created_at: :asc).includes(:results)
       render json: { data: teams }
     end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,5 @@
 class Team < ApplicationRecord
+  has_many :results, class_name: 'TeamResult'
+
   enum league: { central: 0, pacific: 1 }
 end

--- a/app/models/team_result.rb
+++ b/app/models/team_result.rb
@@ -1,0 +1,3 @@
+class TeamResult < ApplicationRecord
+  belongs_to :team
+end

--- a/db/fixtures/1000_teams.rb
+++ b/db/fixtures/1000_teams.rb
@@ -13,6 +13,8 @@ team_list = [
   { name: 'オリックス・バファローズ', founded_year: 1936, league: 1 },
 ]
 
+year = 2020
+
 team_list.map do |team|
   Team.seed(
     :name,
@@ -20,6 +22,45 @@ team_list.map do |team|
       name: team[:name],
       founded_year: team[:founded_year],
       league: team[:league],
+    }
+  )
+
+  name = team[:name]
+  case name
+  when '読売ジャイアンツ'
+    rank, wins_count, loses_count = 1, 67, 45
+  when '阪神タイガース'
+    rank, wins_count, loses_count = 2, 60, 53
+  when '中日ドラゴンズ'
+    rank, wins_count, loses_count = 3, 60, 55
+  when '横浜DeNAベイスターズ'
+    rank, wins_count, loses_count = 4, 56, 58
+  when '広島東洋カープ'
+    rank, wins_count, loses_count = 5, 52, 56
+  when '東京ヤクルトスワローズ'
+    rank, wins_count, loses_count = 6, 41, 69
+  when '福岡ソフトバンクホークス'
+    rank, wins_count, loses_count = 1, 73, 42
+  when '千葉ロッテマリーンズ'
+    rank, wins_count, loses_count = 2, 60, 57
+  when '埼玉西武ライオンズ'
+    rank, wins_count, loses_count = 3, 58, 58
+  when '東北楽天ゴールデンイーグルス'
+    rank, wins_count, loses_count = 4, 55, 57
+  when '北海道日本ハムファイターズ'
+    rank, wins_count, loses_count = 5, 53, 62
+  when 'オリックス・バファローズ'
+    rank, wins_count, loses_count = 6, 45, 68
+  end
+
+  TeamResult.seed(
+    :team_id, :year,
+    {
+      team_id: Team.find_by!(name: name).id,
+      year: year,
+      rank: rank,
+      wins_count: wins_count,
+      loses_count: loses_count,
     }
   )
 end

--- a/db/migrate/20210524130734_create_team_results.rb
+++ b/db/migrate/20210524130734_create_team_results.rb
@@ -1,0 +1,15 @@
+class CreateTeamResults < ActiveRecord::Migration[6.0]
+  def change
+    create_table :team_results do |t|
+      t.references :team, foreign_key: true, index: false, null: false
+      t.integer :year, null: false
+      t.integer :rank, null: false
+      t.integer :wins_count, null: false, default: 0
+      t.integer :loses_count, null: false, default: 0
+
+      t.timestamps
+
+      t.index [:team_id, :year], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_114733) do
+ActiveRecord::Schema.define(version: 2021_05_24_130734) do
+
+  create_table "team_results", force: :cascade do |t|
+    t.integer "team_id", null: false
+    t.integer "year", null: false
+    t.integer "rank", null: false
+    t.integer "wins_count", default: 0, null: false
+    t.integer "loses_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["team_id", "year"], name: "index_team_results_on_team_id_and_year", unique: true
+  end
 
   create_table "teams", force: :cascade do |t|
     t.string "name", null: false
@@ -20,4 +31,5 @@ ActiveRecord::Schema.define(version: 2021_05_18_114733) do
     t.integer "league", default: 0, null: false
   end
 
+  add_foreign_key "team_results", "teams"
 end


### PR DESCRIPTION
`GET /api/teams`

returns

```rb
[
  {
    id: 1,
    name: '読売ジャイアンツ',
    founded_year: 1934,
    created_at: '2021-05-25T12:48:50.957Z',
    updated_at: '2021-05-25T12:48:50.957Z',
    league: 'central',
    results: [ { id: 1, team_id: 1, year: 2020, rank: 1, wins: 67, …}, {...} ]
  },
  {…},
  ...
]
```