### PR TITLE
Heroku の Application error を解決

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "action_mailer/railtie"
 # require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
+require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 


### PR DESCRIPTION
Heroku で Application error が発生。
エラーログを辿ると `uninitialized constant ApplicationCable::ActionCable (NameError)`とあったため、消していた`action_cable`を復活。